### PR TITLE
Update LMEvalJob CRD to pass secrets

### DIFF
--- a/api/OpenAPI.yaml
+++ b/api/OpenAPI.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: '3.1.0'
 info:
   title: LM Evaluation Harness API
   description: API for submitting, polling, and retrieving results of LM Evaluation Harness jobs.
@@ -56,6 +56,53 @@ paths:
                 include_path:
                   type: string
                   description: Path to include in the evaluation.
+                secrets:
+                  type: array
+                  description: Provide the secrets to run the evulation job
+                  items:
+                    type: object
+                    description: create environment variables to store the secrets or mount the secrets as files
+                    oneOf:
+                      - properties:
+                          mountPath:
+                            type: string
+                            description: where to mount the secret object to
+                          referenceObj:
+                            type: object
+                            description: use a secret object
+                            properties:
+                              name:
+                                type: string
+                                description: secret object's name
+                              files:
+                                type: array
+                                description: specify the keys in a secret object and the path
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                      description: specify the key of the secret object
+                                    path:
+                                      type: string
+                                      description: specify the file path
+                      - properties:
+                          env:
+                            type: string
+                            description: use the environment variable to access the secret
+                          key:
+                            type: string
+                            description: the secret value
+                          referenceObj:
+                            type: object
+                            description: use a secret object
+                            properties:
+                              name:
+                                type: string
+                                description: secret object's name
+                              key:
+                                type: string
+                                description: specify the key of the secret object
               required:
                 - model
                 - tasks

--- a/api/v1beta1/lmevaljob_types.go
+++ b/api/v1beta1/lmevaljob_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -59,9 +60,26 @@ type Arg struct {
 	Value string `json:"value,omitempty"`
 }
 
+type EnvSecret struct {
+	// Environment's name
+	Env string `json:"env"`
+	// The secret is from a secret object
+	// +optional
+	SecretRef *corev1.SecretKeySelector `json:"secretRef,omitempty"`
+	// The secret is from a plain text
+	// +optional
+	Secret *string `json:"secret,omitempty"`
+}
+
+type FileSecret struct {
+	// The secret object
+	SecretRef corev1.SecretVolumeSource `json:"secretRef,omitempty"`
+	// The path to mount the secret
+	MountPath string `json:"mountPath"`
+}
+
 // LMEvalJobSpec defines the desired state of LMEvalJob
 type LMEvalJobSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// Model name
@@ -86,6 +104,11 @@ type LMEvalJobSpec struct {
 	// model, will be saved at per-document granularity
 	// +optional
 	LogSamples *bool `json:"logSamples,omitempty"`
+	// Assign secrets to the environment variables
+	// +optional
+	EnvSecrets []EnvSecret `json:"envSecrets,omitempty"`
+	// Use secrets as files
+	FileSecrets []FileSecret `json:"fileSecrets,omitempty"`
 }
 
 // LMEvalJobStatus defines the observed state of LMEvalJob

--- a/backend/controller/lmevaljob_controller_test.go
+++ b/backend/controller/lmevaljob_controller_test.go
@@ -18,9 +18,12 @@ package controller
 
 import (
 	"context"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -28,6 +31,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	lmevalservicev1beta1 "github.com/foundation-model-stack/fms-lm-eval-service/api/v1beta1"
+)
+
+var (
+	isController                   = true
+	allowPrivilegeEscalation       = false
+	runAsNonRootUser               = true
+	runAsUser                int64 = 1001030000
+	secretMode               int32 = 420
 )
 
 var _ = Describe("LMEvalJob Controller", func() {
@@ -85,3 +96,687 @@ var _ = Describe("LMEvalJob Controller", func() {
 		})
 	})
 })
+
+func Test_SimplePod(t *testing.T) {
+	lmevalRec := LMEvalJobReconciler{
+		Namespace: "test",
+		options: &ServiceOptions{
+			PodImage:        "podimage:latest",
+			DriverImage:     "driver:latest",
+			ImagePullPolicy: corev1.PullAlways,
+			GrpcPort:        8088,
+			GrpcService:     "grpc-service",
+		},
+	}
+	var job = &lmevalservicev1beta1.LMEvalJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			UID:       "for-testing",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       lmevalservicev1beta1.KindName,
+			APIVersion: lmevalservicev1beta1.Version,
+		},
+		Spec: lmevalservicev1beta1.LMEvalJobSpec{
+			Model: "test",
+			ModelArgs: []lmevalservicev1beta1.Arg{
+				{Name: "arg1", Value: "value1"},
+			},
+			Tasks: []string{"task1", "task2"},
+		},
+	}
+
+	expect := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "fms-lm-eval-service",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: lmevalservicev1beta1.Version,
+					Kind:       lmevalservicev1beta1.KindName,
+					Name:       "test",
+					Controller: &isController,
+					UID:        "for-testing",
+				},
+			},
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{
+					Name:            "driver",
+					Image:           lmevalRec.options.DriverImage,
+					ImagePullPolicy: lmevalRec.options.ImagePullPolicy,
+					Command:         []string{DriverPath, "--copy", DestDriverPath},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+						RunAsUser:                &runAsUser,
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{
+								"ALL",
+							},
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "shared",
+							MountPath: "/opt/app-root/src/bin",
+						},
+					},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:            "main",
+					Image:           lmevalRec.options.PodImage,
+					ImagePullPolicy: lmevalRec.options.ImagePullPolicy,
+					Env:             []corev1.EnvVar{},
+					Command:         lmevalRec.generateCmd(job),
+					Args:            generateArgs(job),
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+						RunAsUser:                &runAsUser,
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{
+								"ALL",
+							},
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "shared",
+							MountPath: "/opt/app-root/src/bin",
+						},
+					},
+				},
+			},
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: &runAsNonRootUser,
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "shared", VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+
+	newPod := lmevalRec.createPod(job)
+
+	assert.Equal(t, expect, newPod)
+}
+
+func Test_GrpcMTlsPod(t *testing.T) {
+	lmevalRec := LMEvalJobReconciler{
+		Namespace: "test",
+		options: &ServiceOptions{
+			PodImage:         "podimage:latest",
+			DriverImage:      "driver:latest",
+			ImagePullPolicy:  corev1.PullAlways,
+			GrpcPort:         8088,
+			GrpcService:      "grpc-service",
+			GrpcServerSecret: "server-secret",
+			GrpcClientSecret: "client-secret",
+			grpcTLSMode:      TLSMode_mTLS,
+		},
+	}
+	var job = &lmevalservicev1beta1.LMEvalJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			UID:       "for-testing",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       lmevalservicev1beta1.KindName,
+			APIVersion: lmevalservicev1beta1.Version,
+		},
+		Spec: lmevalservicev1beta1.LMEvalJobSpec{
+			Model: "test",
+			ModelArgs: []lmevalservicev1beta1.Arg{
+				{Name: "arg1", Value: "value1"},
+			},
+			Tasks: []string{"task1", "task2"},
+		},
+	}
+
+	expect := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "fms-lm-eval-service",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: lmevalservicev1beta1.Version,
+					Kind:       lmevalservicev1beta1.KindName,
+					Name:       "test",
+					Controller: &isController,
+					UID:        "for-testing",
+				},
+			},
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{
+					Name:            "driver",
+					Image:           lmevalRec.options.DriverImage,
+					ImagePullPolicy: lmevalRec.options.ImagePullPolicy,
+					Command:         []string{DriverPath, "--copy", DestDriverPath},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+						RunAsUser:                &runAsUser,
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{
+								"ALL",
+							},
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "shared",
+							MountPath: "/opt/app-root/src/bin",
+						},
+					},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:            "main",
+					Image:           lmevalRec.options.PodImage,
+					ImagePullPolicy: lmevalRec.options.ImagePullPolicy,
+					Env: []corev1.EnvVar{
+						{
+							Name:  "GRPC_CLIENT_KEY",
+							Value: "/tmp/k8s-grpc-client/certs/tls.key",
+						},
+						{
+							Name:  "GRPC_CLIENT_CERT",
+							Value: "/tmp/k8s-grpc-client/certs/tls.crt",
+						},
+						{
+							Name:  "GRPC_SERVER_CA",
+							Value: "/tmp/k8s-grpc-server/certs/ca.crt",
+						},
+					},
+					Command: lmevalRec.generateCmd(job),
+					Args:    generateArgs(job),
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+						RunAsUser:                &runAsUser,
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{
+								"ALL",
+							},
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "shared",
+							MountPath: "/opt/app-root/src/bin",
+						},
+						{
+							Name:      "client-cert",
+							MountPath: "/tmp/k8s-grpc-client/certs",
+							ReadOnly:  true,
+						},
+						{
+							Name:      "server-cert",
+							MountPath: "/tmp/k8s-grpc-server/certs",
+							ReadOnly:  true,
+						},
+					},
+				},
+			},
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: &runAsNonRootUser,
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "shared", VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+				{
+					Name: "client-cert",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName:  lmevalRec.options.GrpcClientSecret,
+							DefaultMode: &secretMode,
+						},
+					},
+				},
+				{
+					Name: "server-cert",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName:  lmevalRec.options.GrpcServerSecret,
+							DefaultMode: &secretMode,
+							Items: []corev1.KeyToPath{
+								{Key: "ca.crt", Path: "ca.crt"},
+							},
+						},
+					},
+				},
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+
+	newPod := lmevalRec.createPod(job)
+
+	assert.Equal(t, expect, newPod)
+}
+
+func Test_EnvSecretsPod(t *testing.T) {
+	lmevalRec := LMEvalJobReconciler{
+		Namespace: "test",
+		options: &ServiceOptions{
+			PodImage:         "podimage:latest",
+			DriverImage:      "driver:latest",
+			ImagePullPolicy:  corev1.PullAlways,
+			GrpcPort:         8088,
+			GrpcService:      "grpc-service",
+			GrpcServerSecret: "server-secret",
+			GrpcClientSecret: "client-secret",
+			grpcTLSMode:      TLSMode_mTLS,
+		},
+	}
+	var job = &lmevalservicev1beta1.LMEvalJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			UID:       "for-testing",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       lmevalservicev1beta1.KindName,
+			APIVersion: lmevalservicev1beta1.Version,
+		},
+		Spec: lmevalservicev1beta1.LMEvalJobSpec{
+			Model: "test",
+			ModelArgs: []lmevalservicev1beta1.Arg{
+				{Name: "arg1", Value: "value1"},
+			},
+			Tasks: []string{"task1", "task2"},
+			EnvSecrets: []lmevalservicev1beta1.EnvSecret{
+				{
+					Env: "my_env",
+					SecretRef: &corev1.SecretKeySelector{
+						Key: "my-key",
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "my-secret",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expect := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "fms-lm-eval-service",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: lmevalservicev1beta1.Version,
+					Kind:       lmevalservicev1beta1.KindName,
+					Name:       "test",
+					Controller: &isController,
+					UID:        "for-testing",
+				},
+			},
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{
+					Name:            "driver",
+					Image:           lmevalRec.options.DriverImage,
+					ImagePullPolicy: lmevalRec.options.ImagePullPolicy,
+					Command:         []string{DriverPath, "--copy", DestDriverPath},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+						RunAsUser:                &runAsUser,
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{
+								"ALL",
+							},
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "shared",
+							MountPath: "/opt/app-root/src/bin",
+						},
+					},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:            "main",
+					Image:           lmevalRec.options.PodImage,
+					ImagePullPolicy: lmevalRec.options.ImagePullPolicy,
+					Env: []corev1.EnvVar{
+						{
+							Name: "my_env",
+							ValueFrom: &corev1.EnvVarSource{
+								SecretKeyRef: &corev1.SecretKeySelector{
+									Key: "my-key",
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "my-secret",
+									},
+								},
+							},
+						},
+						{
+							Name:  "GRPC_CLIENT_KEY",
+							Value: "/tmp/k8s-grpc-client/certs/tls.key",
+						},
+						{
+							Name:  "GRPC_CLIENT_CERT",
+							Value: "/tmp/k8s-grpc-client/certs/tls.crt",
+						},
+						{
+							Name:  "GRPC_SERVER_CA",
+							Value: "/tmp/k8s-grpc-server/certs/ca.crt",
+						},
+					},
+					Command: lmevalRec.generateCmd(job),
+					Args:    generateArgs(job),
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+						RunAsUser:                &runAsUser,
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{
+								"ALL",
+							},
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "shared",
+							MountPath: "/opt/app-root/src/bin",
+						},
+						{
+							Name:      "client-cert",
+							MountPath: "/tmp/k8s-grpc-client/certs",
+							ReadOnly:  true,
+						},
+						{
+							Name:      "server-cert",
+							MountPath: "/tmp/k8s-grpc-server/certs",
+							ReadOnly:  true,
+						},
+					},
+				},
+			},
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: &runAsNonRootUser,
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "shared", VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+				{
+					Name: "client-cert",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName:  lmevalRec.options.GrpcClientSecret,
+							DefaultMode: &secretMode,
+						},
+					},
+				},
+				{
+					Name: "server-cert",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName:  lmevalRec.options.GrpcServerSecret,
+							DefaultMode: &secretMode,
+							Items: []corev1.KeyToPath{
+								{Key: "ca.crt", Path: "ca.crt"},
+							},
+						},
+					},
+				},
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+
+	newPod := lmevalRec.createPod(job)
+	// maybe only verify the envs: Containers[0].Env
+	assert.Equal(t, expect, newPod)
+}
+
+func Test_FileSecretsPod(t *testing.T) {
+	lmevalRec := LMEvalJobReconciler{
+		Namespace: "test",
+		options: &ServiceOptions{
+			PodImage:         "podimage:latest",
+			DriverImage:      "driver:latest",
+			ImagePullPolicy:  corev1.PullAlways,
+			GrpcPort:         8088,
+			GrpcService:      "grpc-service",
+			GrpcServerSecret: "server-secret",
+			GrpcClientSecret: "client-secret",
+			grpcTLSMode:      TLSMode_mTLS,
+		},
+	}
+	var job = &lmevalservicev1beta1.LMEvalJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			UID:       "for-testing",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       lmevalservicev1beta1.KindName,
+			APIVersion: lmevalservicev1beta1.Version,
+		},
+		Spec: lmevalservicev1beta1.LMEvalJobSpec{
+			Model: "test",
+			ModelArgs: []lmevalservicev1beta1.Arg{
+				{Name: "arg1", Value: "value1"},
+			},
+			Tasks: []string{"task1", "task2"},
+			FileSecrets: []lmevalservicev1beta1.FileSecret{
+				{
+					MountPath: "the_path",
+					SecretRef: corev1.SecretVolumeSource{
+						SecretName: "my-secret",
+						Items: []corev1.KeyToPath{
+							{
+								Key:  "key1",
+								Path: "path1",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expect := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "fms-lm-eval-service",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: lmevalservicev1beta1.Version,
+					Kind:       lmevalservicev1beta1.KindName,
+					Name:       "test",
+					Controller: &isController,
+					UID:        "for-testing",
+				},
+			},
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{
+					Name:            "driver",
+					Image:           lmevalRec.options.DriverImage,
+					ImagePullPolicy: lmevalRec.options.ImagePullPolicy,
+					Command:         []string{DriverPath, "--copy", DestDriverPath},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+						RunAsUser:                &runAsUser,
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{
+								"ALL",
+							},
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "shared",
+							MountPath: "/opt/app-root/src/bin",
+						},
+					},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:            "main",
+					Image:           lmevalRec.options.PodImage,
+					ImagePullPolicy: lmevalRec.options.ImagePullPolicy,
+					Env: []corev1.EnvVar{
+						{
+							Name:  "GRPC_CLIENT_KEY",
+							Value: "/tmp/k8s-grpc-client/certs/tls.key",
+						},
+						{
+							Name:  "GRPC_CLIENT_CERT",
+							Value: "/tmp/k8s-grpc-client/certs/tls.crt",
+						},
+						{
+							Name:  "GRPC_SERVER_CA",
+							Value: "/tmp/k8s-grpc-server/certs/ca.crt",
+						},
+					},
+					Command: lmevalRec.generateCmd(job),
+					Args:    generateArgs(job),
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+						RunAsUser:                &runAsUser,
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{
+								"ALL",
+							},
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "shared",
+							MountPath: "/opt/app-root/src/bin",
+						},
+						{
+							Name:      "client-cert",
+							MountPath: "/tmp/k8s-grpc-client/certs",
+							ReadOnly:  true,
+						},
+						{
+							Name:      "server-cert",
+							MountPath: "/tmp/k8s-grpc-server/certs",
+							ReadOnly:  true,
+						},
+						{
+							Name:      "secVol1",
+							MountPath: "the_path",
+							ReadOnly:  true,
+						},
+					},
+				},
+			},
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: &runAsNonRootUser,
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "shared", VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+				{
+					Name: "client-cert",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName:  lmevalRec.options.GrpcClientSecret,
+							DefaultMode: &secretMode,
+						},
+					},
+				},
+				{
+					Name: "server-cert",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName:  lmevalRec.options.GrpcServerSecret,
+							DefaultMode: &secretMode,
+							Items: []corev1.KeyToPath{
+								{Key: "ca.crt", Path: "ca.crt"},
+							},
+						},
+					},
+				},
+				{
+					Name: "secVol1",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "my-secret",
+							Items: []corev1.KeyToPath{
+								{
+									Key:  "key1",
+									Path: "path1",
+								},
+							},
+						},
+					},
+				},
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+
+	newPod := lmevalRec.createPod(job)
+	// maybe only verify the envs: Containers[0].Env
+	assert.Equal(t, expect, newPod)
+}

--- a/backend/driver/driver.go
+++ b/backend/driver/driver.go
@@ -108,9 +108,18 @@ func (d *driverImpl) Run() error {
 	if err := d.updateStatus(lmevalservicev1beta1.RunningJobState); err != nil {
 		return err
 	}
-	err := d.exec()
+	execErr := d.exec()
 
-	return d.updateCompleteStatus(err)
+	// dump stderr and stdout to the console
+	var toConsole = func(file string) {
+		if data, err := os.ReadFile(file); err == nil {
+			os.Stdout.Write(data)
+		}
+	}
+	toConsole(filepath.Join(d.Option.OutputPath, "stdout.log"))
+	toConsole(filepath.Join(d.Option.OutputPath, "stderr.log"))
+
+	return d.updateCompleteStatus(execErr)
 }
 
 func (d *driverImpl) Cleanup() {

--- a/config/crd/bases/foundation-model-stack.github.com.github.com_lmevaljobs.yaml
+++ b/config/crd/bases/foundation-model-stack.github.com.github.com_lmevaljobs.yaml
@@ -39,6 +39,114 @@ spec:
           spec:
             description: LMEvalJobSpec defines the desired state of LMEvalJob
             properties:
+              envSecrets:
+                description: Assign secrets to the environment variables
+                items:
+                  properties:
+                    env:
+                      description: Environment's name
+                      type: string
+                    secret:
+                      description: The secret is from a plain text
+                      type: string
+                    secretRef:
+                      description: The secret is from a secret object
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  required:
+                  - env
+                  type: object
+                type: array
+              fileSecrets:
+                description: Use secrets as files
+                items:
+                  properties:
+                    mountPath:
+                      description: The path to mount the secret
+                      type: string
+                    secretRef:
+                      description: The secret object
+                      properties:
+                        defaultMode:
+                          description: |-
+                            defaultMode is Optional: mode bits used to set permissions on created files by default.
+                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                            YAML accepts both octal and decimal values, JSON requires decimal values
+                            for mode bits. Defaults to 0644.
+                            Directories within the path are not affected by this setting.
+                            This might be in conflict with other options that affect the file
+                            mode, like fsGroup, and the result can be other mode bits set.
+                          format: int32
+                          type: integer
+                        items:
+                          description: |-
+                            items If unspecified, each key-value pair in the Data field of the referenced
+                            Secret will be projected into the volume as a file whose name is the
+                            key and content is the value. If specified, the listed keys will be
+                            projected into the specified paths, and unlisted keys will not be
+                            present. If a key is specified which is not present in the Secret,
+                            the volume setup will error unless it is marked optional. Paths must be
+                            relative and may not contain the '..' path or start with '..'.
+                          items:
+                            description: Maps a string key to a path within a volume.
+                            properties:
+                              key:
+                                description: key is the key to project.
+                                type: string
+                              mode:
+                                description: |-
+                                  mode is Optional: mode bits used to set permissions on this file.
+                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                  If not specified, the volume defaultMode will be used.
+                                  This might be in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              path:
+                                description: |-
+                                  path is the relative path of the file to map the key to.
+                                  May not be an absolute path.
+                                  May not contain the path element '..'.
+                                  May not start with the string '..'.
+                                type: string
+                            required:
+                            - key
+                            - path
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        optional:
+                          description: optional field specify whether the Secret or
+                            its keys must be defined
+                          type: boolean
+                        secretName:
+                          description: |-
+                            secretName is the name of the secret in the pod's namespace to use.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                          type: string
+                      type: object
+                  required:
+                  - mountPath
+                  type: object
+                type: array
               genArgs:
                 description: Map to `--gen_kwargs` parameter for the underlying library.
                 items:

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.32.0
 	github.com/spf13/viper v1.19.0
+	github.com/stretchr/testify v1.9.0
 	google.golang.org/grpc v1.64.0
 	google.golang.org/protobuf v1.34.2
 	k8s.io/api v0.30.0
@@ -50,6 +51,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.16.0 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.44.0 // indirect

--- a/server/static/api.json
+++ b/server/static/api.json
@@ -70,6 +70,77 @@
                   "include_path": {
                     "type": "string",
                     "description": "Path to include in the evaluation."
+                  },
+                  "secrets": {
+                    "type": "array",
+                    "description": "Provide the secrets to run the evulation job",
+                    "items": {
+                      "type": "object",
+                      "description": "create environment variables to store the secrets or mount the secrets as files",
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string",
+                              "description": "where to mount the secret object to"
+                            },
+                            "referenceObj": {
+                              "type": "object",
+                              "description": "use a secret object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "secret object's name"
+                                },
+                                "files": {
+                                  "type": "array",
+                                  "description": "specify the keys in a secret object and the path",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "key": {
+                                        "type": "string",
+                                        "description": "specify the key of the secret object"
+                                      },
+                                      "path": {
+                                        "type": "string",
+                                        "description": "specify the file path"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "env": {
+                              "type": "string",
+                              "description": "use the environment variable to access the secret"
+                            },
+                            "key": {
+                              "type": "string",
+                              "description": "the secret value"
+                            },
+                            "referenceObj": {
+                              "type": "object",
+                              "description": "use a secret object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "secret object's name"
+                                },
+                                "key": {
+                                  "type": "string",
+                                  "description": "specify the key of the secret object"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
                   }
                 },
                 "required": [


### PR DESCRIPTION
Add the `envSecrets` field to pass the secrets.
Each of the EnvSecret could be either an API key
or a secret object reference.

fixed: #17 